### PR TITLE
Added index failure checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Just download the source and build it yourself using the go-tools.
 ## Usage:
 
     check_graylog2
+      -c string
+          	Index Critical Limit
       -l string
             Graylog2 API URL (default "http://localhost:12900")
       -p string
@@ -33,28 +35,42 @@ Just download the source and build it yourself using the go-tools.
             Accept insecure SSL/TLS certificates.
       -version
             Display version and license information.
-
+      -w string
+            Index Error Limit
+ 
 ## Debugging:
 
 Please try your command with the environment variable set as `NCG2=debug` or prefixing your command for example on linux like this.
 
-    NCG2=debug /usr/local/nagios/libexec/check_graylog2 -l http://localhost:9000/api/ -u USERNAME -p PASSWORD
+    NCG2=debug /usr/local/nagios/libexec/check_graylog2 -l http://localhost:9000/api/ -u USERNAME -p PASSWORD -w 10 -c 20
 
 ## Examples:
 
-    $ ./check_graylog2 -l http://localhost:12900 -u USERNAME -p PASSWORD
+    $ ./check_graylog2 -l http://localhost:12900 -u USERNAME -p PASSWORD -w 10 -c 20
     OK - Service is running!
     768764376 total events processed
     0 index failures
     297 throughput
     1 sources
-    Check took 94ms|time=0.0094;;;; total=768764376;;;; sources=1;;;; throughput=297;;;; index_failures=0;;;;
+    Check took 94ms
+    |time=0.0094;;;; total=768764376;;;; sources=1;;;; throughput=297;;;; index_failures=0;;;;
 
-    $ ./check_graylog2 -l http://localhost:12900 -u USERNAME -p PASSWORD
+    $ ./check_graylog2 -l http://localhost:12900 -u USERNAME -p PASSWORD -w 10 -c 20
     CRITICAL - Can not connect to Graylog2 API|time=0.000000;;;; total=0;;;; sources=0;;;; throughput=0;;;; index_failures=0;;;;
 
-    $ ./check_graylog2 -l https://localhost -insecure -u USERNAME -p PASSWORD
+    $ ./check_graylog2 -l https://localhost -insecure -u USERNAME -p PASSWORD -w 10 -c 20
     UNKNOWN - Port number is missing. Try https://hostname:port|time=0.000000;;;; total=0;;;; sources=0;;;; throughput=0;;;; index_failures=0;;;;
+    
+     $ ./check_graylog2 -l http://localhost:12900 -u USERNAME -p PASSWORD -w 10 -c 20
+    CRITICAL - Indexer Failure Critical!
+    Service is running
+    533732628 total events processed
+    21 index failures
+    297 throughput
+    1 sources
+    Check took 94ms
+    |time=0.0094;;;; total=533732628;;;; sources=1;;;; throughput=297;;;; index_failures=21;;;;
+
 
 ## Return Values:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Please try your command with the environment variable set as `NCG2=debug` or pre
     UNKNOWN - Port number is missing. Try https://hostname:port|time=0.000000;;;; total=0;;;; sources=0;;;; throughput=0;;;; index_failures=0;;;;
     
      $ ./check_graylog2 -l http://localhost:12900 -u USERNAME -p PASSWORD -w 10 -c 20
-    CRITICAL - Indexer Failure Critical!
+    CRITICAL - Index Failure above Critical Limit!
     Service is running
     533732628 total events processed
     21 index failures

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -26,18 +27,18 @@ const DEBUG = "NCG2"
 
 // license information
 const (
-        author = "Antonino Catinello"
-        license = "BSD"
-        year = "2016"
-        copyright = "\u00A9"
+	author       = "Antonino Catinello"
+	license      = "BSD"
+	year         = "2016"
+	copyright    = "\u00A9"
+	contributers = "kahluagenie, theherodied"
 )
-
 
 var (
 	// command line arguments
-	link *string
-	user *string
-	pass *string
+	link    *string
+	user    *string
+	pass    *string
 	version *bool
 	// using ssl to avoid name conflict with tls
 	ssl *bool
@@ -46,7 +47,9 @@ var (
 	// performence data
 	pdata string
 	// version value
-	id string
+	id        string
+	indexwarn *string
+	indexcrit *string
 )
 
 // handle performence data output
@@ -56,13 +59,15 @@ func perf(elapsed, total, inputs, tput, index float64) {
 
 // handle args
 func init() {
-	link = flag.String("l", "http://localhost:12900", "Graylog2 API URL")
+	link = flag.String("l", "http://localhost:12900", "Graylog API URL")
 	user = flag.String("u", "", "API username")
 	pass = flag.String("p", "", "API password")
 	ssl = flag.Bool("insecure", false, "Accept insecure SSL/TLS certificates.")
 	version = flag.Bool("version", false, "Display version and license information.")
 	debug = os.Getenv(DEBUG)
 	perf(0, 0, 0, 0, 0)
+	indexwarn = flag.String("w", "", "Index Error Limit")
+	indexcrit = flag.String("c", "", "Index Critical Limit")
 }
 
 // return nagios codes on quit
@@ -112,11 +117,19 @@ func main() {
 	flag.Parse()
 
 	if *version {
-		fmt.Printf("Version: %v License: %v %v %v %v\n", id, license, copyright, year, author)
+		fmt.Printf("Version: %v License: %v %v %v %v\nContributers: %v\n", id, license, copyright, year, author, contributers)
 		os.Exit(3)
 	}
 
 	if len(*user) == 0 || len(*pass) == 0 {
+		flag.PrintDefaults()
+		os.Exit(3)
+	}
+	if len(*indexwarn) == 0 {
+		flag.PrintDefaults()
+		os.Exit(3)
+	}
+	if len(*indexcrit) == 0 {
 		flag.PrintDefaults()
 		os.Exit(3)
 	}
@@ -142,12 +155,32 @@ func main() {
 
 	elapsed := time.Since(start)
 
-	perf(elapsed.Seconds(), total["events"].(float64), inputs["total"].(float64), tput["throughput"].(float64), index["total"].(float64))
-	quit(OK, fmt.Sprintf("Service is running!\n%.f total events processed\n%.f index failures\n%.f throughput\n%.f sources\nCheck took %v",
-		total["events"].(float64), index["total"].(float64), tput["throughput"].(float64), inputs["total"].(float64), elapsed), nil)
+	indexwarn2, err := strconv.ParseFloat((*indexwarn), 64)
+	if err != nil {
+	}
+	indexcrit2, err := strconv.ParseFloat((*indexcrit), 64)
+	if err != nil {
+	}
+
+	if index["total"].(float64) < indexwarn2 && index["total"].(float64) < indexcrit2 {
+		perf(elapsed.Seconds(), total["events"].(float64), inputs["total"].(float64), tput["throughput"].(float64), index["total"].(float64))
+		quit(OK, fmt.Sprintf("Service is running!\n%.f total events processed\n%.f index failures\n%.f throughput\n%.f sources\nCheck took %v\n",
+			total["events"].(float64), index["total"].(float64), tput["throughput"].(float64), inputs["total"].(float64), elapsed), nil)
+	}
+	if index["total"].(float64) >= indexwarn2 && index["total"].(float64) < indexcrit2 {
+		perf(elapsed.Seconds(), total["events"].(float64), inputs["total"].(float64), tput["throughput"].(float64), index["total"].(float64))
+		quit(WARNING, fmt.Sprintf("Indexer Failure Warning!\nService is running\n%.f total events processed\n%.f index failures\n%.f throughput\n%.f sources\nCheck took %v\n",
+			total["events"].(float64), index["total"].(float64), tput["throughput"].(float64), inputs["total"].(float64), elapsed), nil)
+	}
+	if index["total"].(float64) >= indexcrit2 {
+		perf(elapsed.Seconds(), total["events"].(float64), inputs["total"].(float64), tput["throughput"].(float64), index["total"].(float64))
+		quit(CRITICAL, fmt.Sprintf("Indexer Failure Critical!\nService is running\n%.f total events processed\n%.f index failures\n%.f throughput\n%.f sources\nCheck took %v\n",
+			total["events"].(float64), index["total"].(float64), tput["throughput"].(float64), inputs["total"].(float64), elapsed), nil)
+	}
+
 }
 
-// call Graylog2 HTTP API
+// call Graylog HTTP API
 func query(target string, user string, pass string) map[string]interface{} {
 	var client *http.Client
 	var data map[string]interface{}
@@ -169,13 +202,13 @@ func query(target string, user string, pass string) map[string]interface{} {
 
 	res, err := client.Do(req)
 	if err != nil {
-		quit(CRITICAL, "Can not connect to Graylog2 API", err)
+		quit(CRITICAL, "Can not connect to Graylog API", err)
 	}
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		quit(CRITICAL, "No response received from Graylog2 API", err)
+		quit(CRITICAL, "No response received from Graylog API", err)
 	}
 
 	if len(debug) != 0 {
@@ -184,11 +217,11 @@ func query(target string, user string, pass string) map[string]interface{} {
 
 	err = json.Unmarshal(body, &data)
 	if err != nil {
-		quit(UNKNOWN, "Can not parse JSON from Graylog2 API", err)
+		quit(UNKNOWN, "Can not parse JSON from Graylog API", err)
 	}
 
 	if res.StatusCode != 200 {
-		quit(CRITICAL, fmt.Sprintf("Graylog2 API replied with HTTP code %v", res.StatusCode), err)
+		quit(CRITICAL, fmt.Sprintf("Graylog API replied with HTTP code %v", res.StatusCode), err)
 	}
 
 	return data

--- a/main.go
+++ b/main.go
@@ -169,12 +169,12 @@ func main() {
 	}
 	if index["total"].(float64) >= indexwarn2 && index["total"].(float64) < indexcrit2 {
 		perf(elapsed.Seconds(), total["events"].(float64), inputs["total"].(float64), tput["throughput"].(float64), index["total"].(float64))
-		quit(WARNING, fmt.Sprintf("Indexer Failure Warning!\nService is running\n%.f total events processed\n%.f index failures\n%.f throughput\n%.f sources\nCheck took %v\n",
+		quit(WARNING, fmt.Sprintf("Index Failure above Warning Limit!\nService is running\n%.f total events processed\n%.f index failures\n%.f throughput\n%.f sources\nCheck took %v\n",
 			total["events"].(float64), index["total"].(float64), tput["throughput"].(float64), inputs["total"].(float64), elapsed), nil)
 	}
 	if index["total"].(float64) >= indexcrit2 {
 		perf(elapsed.Seconds(), total["events"].(float64), inputs["total"].(float64), tput["throughput"].(float64), index["total"].(float64))
-		quit(CRITICAL, fmt.Sprintf("Indexer Failure Critical!\nService is running\n%.f total events processed\n%.f index failures\n%.f throughput\n%.f sources\nCheck took %v\n",
+		quit(CRITICAL, fmt.Sprintf("Index Failure above Critical Limit!\nService is running\n%.f total events processed\n%.f index failures\n%.f throughput\n%.f sources\nCheck took %v\n",
 			total["events"].(float64), index["total"].(float64), tput["throughput"].(float64), inputs["total"].(float64), elapsed), nil)
 	}
 

--- a/main.go
+++ b/main.go
@@ -154,8 +154,8 @@ func main() {
 	total := query(c+"/count/total", *user, *pass)
 
 	elapsed := time.Since(start)
-	
-	//convert indexwarn and indexcrit strings to float64 for comparison below 
+
+	// convert indexwarn and indexcrit strings to float64 variables for comparison below
 	indexwarn2, err := strconv.ParseFloat((*indexwarn), 64)
 	if err != nil {
 		quit(UNKNOWN, "Can not parse index warning errors.", err)

--- a/main.go
+++ b/main.go
@@ -154,12 +154,15 @@ func main() {
 	total := query(c+"/count/total", *user, *pass)
 
 	elapsed := time.Since(start)
-
+	
+	//convert indexwarn and indexcrit strings to float64 for comparison below 
 	indexwarn2, err := strconv.ParseFloat((*indexwarn), 64)
 	if err != nil {
+		quit(UNKNOWN, "Can not parse index warning errors.", err)
 	}
 	indexcrit2, err := strconv.ParseFloat((*indexcrit), 64)
 	if err != nil {
+		quit(UNKNOWN, "Can not parse index critical errors.", err)
 	}
 
 	if index["total"].(float64) < indexwarn2 && index["total"].(float64) < indexcrit2 {


### PR DESCRIPTION
Added index failure checks using -w for warning and -c for critical.
Added contributers = "kahluagenie, theherodied"

Example: If index failures exceeds critical limit it will return:
+     $ ./check_graylog2 -l http://localhost:12900 -u USERNAME -p PASSWORD -w 10 -c 20
+    CRITICAL - Index Failure above Critical Limit!
+    Service is running
+    533732628 total events processed
+    21 index failures
+    297 throughput
+    1 sources
+    Check took 94ms
+    |time=0.0094;;;; total=533732628;;;; sources=1;;;; throughput=297;;;; index_failures=21;;;;